### PR TITLE
add : layout state / waiting - member modal

### DIFF
--- a/booklog/components/BookClub/BottomBox.tsx
+++ b/booklog/components/BookClub/BottomBox.tsx
@@ -1,6 +1,6 @@
 import { clubInfo } from "../../res/interface/BookClubInterface";
 import BottomBoxItem from "./BottomBoxItem";
-import { useRecoilState, useResetRecoilState } from "recoil";
+import { useRecoilState } from "recoil";
 import {
   nameKeywordState,
   tagKeywordState,

--- a/booklog/components/BookClub/BottomBoxItem.tsx
+++ b/booklog/components/BookClub/BottomBoxItem.tsx
@@ -1,8 +1,10 @@
-import { clubInfo } from "../../res/interface/BookClubInterface";
+import { clubInfo, MyStateInClub } from "../../res/interface/BookClubInterface";
 import { useState } from "react";
 import Image from "next/image";
 import BasicModal from "./../BasicModal";
 import ClubModal from "./ClubModal";
+import ClubModalWaiting from "./ClubModalWaiting";
+import ClubModalToMember from "./ClubModalToMember";
 
 interface itemProps {
   item: clubInfo;
@@ -11,6 +13,10 @@ interface itemProps {
 export default function BottomBoxItem(props: itemProps) {
   const { item } = props;
   const [modalOpen, setModalOpen] = useState(false);
+
+  //내가 모임 권한이 어떤거인지 임시 state
+  const [myState, setMyState] = useState(MyStateInClub.Member);
+
   return (
     <>
       <div className="container" onClick={() => setModalOpen(true)}>
@@ -94,7 +100,21 @@ export default function BottomBoxItem(props: itemProps) {
         close={() => setModalOpen(false)}
         header={`${item.name} 모임`}
       >
-        <ClubModal item={item} />
+        {myState === MyStateInClub.NoMember ? (
+          <ClubModal item={item} />
+        ) : myState === MyStateInClub.Waiting ? (
+          <ClubModalWaiting
+            item={item}
+            closeModal={() => setModalOpen(false)}
+          />
+        ) : myState === MyStateInClub.Member ? (
+          <ClubModalToMember
+            item={item}
+            closeModal={() => setModalOpen(false)}
+          />
+        ) : (
+          <></>
+        )}
       </BasicModal>
     </>
   );

--- a/booklog/components/BookClub/ClubModalToMember.tsx
+++ b/booklog/components/BookClub/ClubModalToMember.tsx
@@ -1,0 +1,167 @@
+import { clubInfo } from "../../res/interface/BookClubInterface";
+import Image from "next/image";
+import Router from "next/router";
+
+interface itemProps {
+  item: clubInfo;
+  closeModal: () => void;
+}
+
+export default function ClubModalToMember(props: itemProps) {
+  const { item, closeModal } = props;
+  const router = Router;
+
+  return (
+    <div className="container">
+      <div className="img-box">
+        <Image src={item.image} layout="fill" objectFit="cover" />
+      </div>
+      <div className="left-box">
+        <div className="info-box">
+          <span className="title">{item.name}</span>
+          <span className="manager">클럽 매니저 - {item.username}</span>
+          <span className="style">
+            {item.onoff ? "대면 모임" : "비대면 모임"} ({item.cur_num}/
+            {item.max_num})
+          </span>
+          <div className="tag-box">
+            {item.tags.map((tag, index) => (
+              <span className="tag" key={`${tag}-${index}`}>
+                #{tag}
+              </span>
+            ))}
+          </div>
+          <span className="content">{item.info}</span>
+        </div>
+        <div className="info-box">
+          <button className="enter-btn" onClick={() => closeModal()}>
+            다른 독서모임 구경하기
+          </button>
+          <button
+            className="enter-btn"
+            onClick={() => router.push("/portfolio")}
+          >
+            입장하기
+          </button>
+        </div>
+      </div>
+      <div className="glass" />
+      <Image src={item.image} layout="fill" objectFit="cover" />
+      <style jsx>{`
+        .container {
+          width: 100%;
+          display: flex;
+          flex-direction: row;
+          justify-content: flex-start;
+          align-items: flex-start;
+          gap: 30px;
+          position: relative;
+          padding: 20px;
+        }
+        .glass {
+          position: absolute;
+          width: 100%;
+          height: 100%;
+          top: 50%;
+          left: 50%;
+          transform: translate(-50%, -50%);
+          background: rgba(255, 255, 255, 0.2);
+          backdrop-filter: blur(20px);
+          -webkit-backdrop-filter: blur(20px);
+          z-index: 10;
+          filter: brightness(70%);
+        }
+        .img-box {
+          width: 100%;
+          max-width: 500px;
+          height: 500px;
+          position: relative;
+          z-index: 20;
+          border-radius: 10px;
+          overflow: hidden;
+          box-shadow: rgba(50, 50, 93, 0.25) 0px 13px 27px -5px,
+            rgba(0, 0, 0, 0.3) 0px 8px 16px -8px;
+        }
+        .left-box {
+          height: 500px;
+          display: flex;
+          flex-direction: column;
+          align-items: flex-start;
+          justify-content: center;
+          z-index: 20;
+          gap: 30px;
+          align-self: center;
+        }
+        .info-box {
+          display: flex;
+          flex-direction: column;
+          align-items: flex-start;
+          justify-content: center;
+          gap: 5px;
+        }
+        .title {
+          font-size: 28px;
+          color: white;
+          font-weight: 700;
+          text-shadow: 2px 2px 4px #141414;
+        }
+        .manager {
+          font-size: 16px;
+          font-weight: 400;
+          color: white;
+          text-shadow: 1px 1px 2px #141414;
+        }
+        .style {
+          font-size: 14px;
+          font-weight: 600;
+          background-color: ${item.onoff ? "#125B50" : "#F94C66"};
+          padding: 5px 7px;
+          border-radius: 5px;
+          color: white;
+          box-shadow: rgba(50, 50, 93, 0.25) 0px 13px 27px -5px,
+            rgba(0, 0, 0, 0.3) 0px 8px 16px -8px;
+          margin-top: 2px;
+        }
+        .tag-box {
+          display: flex;
+          flex-direction: row;
+          gap: 5px;
+          font-size: 14px;
+          font-weight: 400;
+          color: white;
+          text-shadow: 1px 1px 2px #141414;
+          flex-wrap: wrap;
+        }
+        .content {
+          text-align: start;
+          white-space: pre-line;
+          word-break: keep-all;
+          background: rgba(255, 255, 255, 0.55);
+          backdrop-filter: blur(17.5px);
+          -webkit-backdrop-filter: blur(17.5px);
+          border-radius: 5px;
+          padding: 20px;
+          margin: 10px 0px;
+          line-height: 22px;
+        }
+        .enter-btn {
+          background-color: #ffffff;
+          border: 2px solid #125b50;
+          color: #125b50;
+          border-radius: 5px;
+          padding: 5px 15px;
+          font-size: 16px;
+          font-weight: 700;
+          font-family: "Pretendard";
+          cursor: pointer;
+          transition: all 0.25s;
+          box-shadow: rgba(0, 0, 0, 0.24) 0px 3px 8px;
+        }
+        .enter-btn:hover {
+          background-color: #125b50;
+          color: white;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/booklog/components/BookClub/ClubModalToMember.tsx
+++ b/booklog/components/BookClub/ClubModalToMember.tsx
@@ -39,7 +39,7 @@ export default function ClubModalToMember(props: itemProps) {
           </button>
           <button
             className="enter-btn"
-            onClick={() => router.push("/portfolio")}
+            onClick={() => router.push(`/bookclub/${item.id}`)}
           >
             입장하기
           </button>

--- a/booklog/components/BookClub/ClubModalWaiting.tsx
+++ b/booklog/components/BookClub/ClubModalWaiting.tsx
@@ -1,0 +1,119 @@
+import { clubInfo } from "../../res/interface/BookClubInterface";
+import Image from "next/image";
+import Router from "next/router";
+
+interface itemProps {
+  item: clubInfo;
+  closeModal: () => void;
+}
+
+export default function ClubModalWaiting(props: itemProps) {
+  const { item, closeModal } = props;
+  const router = Router;
+
+  return (
+    <div className="container">
+      <div className="img-box">
+        <Image src={item.image} layout="fill" objectFit="cover" />
+      </div>
+      <div className="left-box">
+        <div className="info-box">
+          <span className="title">가입신청 승인 절차가 진행 중 입니다.</span>
+          <span className="subtitle">
+            곧 승인이 완료될테니 조금만 기다려주세요!
+          </span>
+        </div>
+        <div className="info-box">
+          <button onClick={() => closeModal()}>다른 독서모임 구경하기</button>
+          <button onClick={() => router.push("/portfolio")}>
+            서평 작성하기
+          </button>
+        </div>
+      </div>
+      <div className="glass" />
+      <Image src={item.image} layout="fill" objectFit="cover" />
+      <style jsx>{`
+        .container {
+          width: 100%;
+          display: flex;
+          flex-direction: row;
+          justify-content: flex-start;
+          align-items: flex-start;
+          gap: 30px;
+          position: relative;
+          padding: 20px;
+        }
+        .glass {
+          position: absolute;
+          width: 100%;
+          height: 100%;
+          top: 50%;
+          left: 50%;
+          transform: translate(-50%, -50%);
+          background: rgba(255, 255, 255, 0.2);
+          backdrop-filter: blur(20px);
+          -webkit-backdrop-filter: blur(20px);
+          z-index: 10;
+          filter: brightness(70%);
+        }
+        .img-box {
+          width: 100%;
+          max-width: 500px;
+          height: 500px;
+          position: relative;
+          z-index: 20;
+          border-radius: 10px;
+          overflow: hidden;
+          box-shadow: rgba(50, 50, 93, 0.25) 0px 13px 27px -5px,
+            rgba(0, 0, 0, 0.3) 0px 8px 16px -8px;
+        }
+        .left-box {
+          height: 500px;
+          display: flex;
+          flex-direction: column;
+          align-items: flex-start;
+          justify-content: center;
+          z-index: 20;
+          gap: 30px;
+          align-self: center;
+        }
+        .info-box {
+          display: flex;
+          flex-direction: column;
+          align-items: flex-start;
+          justify-content: center;
+          gap: 5px;
+        }
+        .title {
+          font-size: 28px;
+          color: white;
+          font-weight: 700;
+          text-shadow: 2px 2px 4px #141414;
+        }
+        .subtitle {
+          font-size: 16px;
+          font-weight: 400;
+          color: white;
+          text-shadow: 1px 1px 2px #141414;
+        }
+        button {
+          background-color: #ffffff;
+          border: 2px solid #125b50;
+          color: #125b50;
+          border-radius: 5px;
+          padding: 5px 15px;
+          font-size: 16px;
+          font-weight: 700;
+          font-family: "Pretendard";
+          cursor: pointer;
+          transition: all 0.25s;
+          box-shadow: rgba(0, 0, 0, 0.24) 0px 3px 8px;
+        }
+        button:hover {
+          background-color: #125b50;
+          color: white;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/booklog/components/BookClub/MakeClub/MakeClubBox.tsx
+++ b/booklog/components/BookClub/MakeClub/MakeClubBox.tsx
@@ -46,6 +46,7 @@ export default function MakeClubBox(props: boxProps) {
   const [imgFile, setImgFile] = useState<File>();
   const [maxNum, setMaxNum] = useState(2);
   const [tags, setTags] = useState<Array<string>>();
+  const [ment, setMent] = useState("");
   const [questions, setQuestions] = useState<Array<string>>();
   const [err, setErr] = useState("");
 
@@ -120,6 +121,7 @@ export default function MakeClubBox(props: boxProps) {
     tags &&
     tags.length > 0 &&
     content !== "" &&
+    ment !== "" &&
     questions &&
     questions.length > 0
       ? setStage(Stage.Complete)
@@ -237,6 +239,18 @@ export default function MakeClubBox(props: boxProps) {
               value={content}
               onChange={(e) => setContent(e.target.value)}
             ></textarea>
+          </li>
+          <li>
+            <label htmlFor="ment" className="vanilla-label">
+              환영 멘트를 작성해주세요.
+            </label>
+            <input
+              id="ment"
+              type="text"
+              placeholder="모임원을 맞이할 짧은 환영 문구를 작성해주세요."
+              value={ment}
+              onChange={(e) => setMent(e.target.value)}
+            />
           </li>
           <li>
             <label htmlFor="questions" className="vanilla-label">

--- a/booklog/components/BookClub/MakeClub/MakeClubLayout.tsx
+++ b/booklog/components/BookClub/MakeClub/MakeClubLayout.tsx
@@ -24,7 +24,7 @@ export default function MakeClubLayout() {
         }
         .upper-box {
           width: 100%;
-          height: 600px;
+          height: 700px;
           background-color: #faf5e4;
           position: relative;
           overflow: hidden;

--- a/booklog/components/BookClub/UpperBox.tsx
+++ b/booklog/components/BookClub/UpperBox.tsx
@@ -46,10 +46,6 @@ export default function UpperBox(props: upperProps) {
     }
   };
 
-  useEffect(() => {
-    console.log(onoff);
-  }, [onoff]);
-
   return (
     <div className="container">
       <span className="title">{`독서는, 함께할 때 진짜니까!`}</span>

--- a/booklog/components/Home/Carousel/Carousel.tsx
+++ b/booklog/components/Home/Carousel/Carousel.tsx
@@ -42,10 +42,6 @@ export default function Carousel(props: carouselProps) {
     clubArray.length > 10 ? setClubArray((prev) => prev.slice(0, 10)) : null;
   }, []);
 
-  useEffect(() => {
-    console.log(moveX);
-  }, [moveX]);
-
   return (
     <div className="container">
       <div className="btns">

--- a/booklog/components/Layout.tsx
+++ b/booklog/components/Layout.tsx
@@ -1,20 +1,31 @@
 import Footer from "./navigation/Footer";
 import Header from "./navigation/Header";
 import User from "./navigation/User";
+import { useRecoilState } from "recoil";
+import { CurrentLayout, ClubLayoutState } from "../states/recoilLayoutState";
 
 const Layout = (props: any) => {
   // 전체 layout 설정
   // 헤더와 푸터는 position을 absolute로 했고,
   // content는 배경 까는 것 때문에 width, height 다 100%로 지정해뒀습니다
+
+  const [layoutState, setLayoutState] = useRecoilState(ClubLayoutState);
+
   return (
     <>
       <div className="container">
-        <header>
-          <Header />
-          <User />
-        </header>
-        <div className="content">{props.children}</div>
-        <Footer />
+        {layoutState === CurrentLayout.Header ? (
+          <>
+            <header>
+              <Header />
+              <User />
+            </header>
+            <div className="content">{props.children}</div>
+            <Footer />
+          </>
+        ) : (
+          <div className="content">{props.children}</div>
+        )}
       </div>
       <style jsx>{`
         .container {

--- a/booklog/pages/bookclub.tsx
+++ b/booklog/pages/bookclub.tsx
@@ -2,6 +2,9 @@ import { GetServerSideProps } from "next";
 import ClubLayout from "../components/BookClub/ClubLayout";
 import Seo from "../components/Seo";
 import { clubInfo } from "../res/interface/BookClubInterface";
+import { useRecoilState } from "recoil";
+import { CurrentLayout, ClubLayoutState } from "../states/recoilLayoutState";
+import { useEffect } from "react";
 
 interface serversideProps {
   clubs: Array<clubInfo>;
@@ -9,6 +12,12 @@ interface serversideProps {
 
 export default function BookClub(props: serversideProps) {
   const { clubs } = props;
+  const [layoutState, setLayoutState] = useRecoilState(ClubLayoutState);
+
+  useEffect(() => {
+    setLayoutState(CurrentLayout.Header);
+  }, []);
+
   return (
     <>
       <Seo title="Book Club" />

--- a/booklog/pages/bookclub/[...params].tsx
+++ b/booklog/pages/bookclub/[...params].tsx
@@ -1,0 +1,63 @@
+import { GetServerSideProps } from "next";
+import Seo from "../../components/Seo";
+import { clubInfo } from "../../res/interface/DynamicBookClubInterface";
+import { useEffect } from "react";
+import { useRecoilState } from "recoil";
+import { CurrentLayout, ClubLayoutState } from "../../states/recoilLayoutState";
+
+interface serversideProps {
+  item: clubInfo;
+  isMember: number;
+}
+
+export default function BookClubDynamicPage(props: serversideProps) {
+  const { item, isMember } = props;
+  const [layoutState, setLayoutState] = useRecoilState(ClubLayoutState);
+
+  useEffect(() => {
+    // 처음 들어왔을 때 헤더 없앰
+    setLayoutState(CurrentLayout.NoHeader);
+  }, []);
+
+  return (
+    <>
+      <Seo title={item.name} />
+    </>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ query }) => {
+  try {
+    const clubId = query.params;
+    const tmpData: clubInfo = {
+      name: "루시가 최고야",
+      id: 123,
+      dates: ["2022-10-27", "2022-10-28", "2022-11-01", "2022-11-02"],
+      image:
+        "https://i.pinimg.com/564x/ff/ac/d8/ffacd8ce790f36a011b1d566a89cb328.jpg",
+      info: "이젠 머리가 어지러워 어느새 해는 져 있고 난 오늘이 무슨 요일인지도 모르고 사나 봐 어질러진 방은 치울 엄두조차 나질 않고 침대 위에 누워 얼마나 잘 수 있나 생각해",
+      max_num: 10,
+      cur_num: 5,
+      ment: "루시 아일랜드",
+      notice: "",
+      onoff: false,
+      tags: [
+        "개화",
+        "떼굴떼굴",
+        "맞네",
+        "결국아무것도알수없었지만",
+        "이미다알고있었지만",
+      ],
+    };
+    //   if (res.status === 200) {
+    //     const artist = res.data;
+    //     return {
+    //       props: { data: artist },
+    //     };
+    //   }
+    return { props: { item: tmpData, isMember: 0 } };
+  } catch (err) {
+    console.log(err);
+    return { props: {} };
+  }
+};

--- a/booklog/pages/index.tsx
+++ b/booklog/pages/index.tsx
@@ -2,6 +2,9 @@ import { GetServerSideProps } from "next";
 import HomeLayout from "../components/Home/HomeLayout";
 import { clubInfo } from "../res/interface/HomeInterface";
 import Seo from "../components/Seo";
+import { useRecoilState } from "recoil";
+import { CurrentLayout, ClubLayoutState } from "../states/recoilLayoutState";
+import { useEffect } from "react";
 
 interface serversideProps {
   clubs: Array<clubInfo>;
@@ -9,6 +12,11 @@ interface serversideProps {
 
 export default function Home(props: serversideProps) {
   const { clubs } = props;
+  const [layoutState, setLayoutState] = useRecoilState(ClubLayoutState);
+
+  useEffect(() => {
+    setLayoutState(CurrentLayout.Header);
+  }, []);
   return (
     <>
       <Seo title="Home" />

--- a/booklog/pages/login.tsx
+++ b/booklog/pages/login.tsx
@@ -1,7 +1,0 @@
-import { NextPage } from "next";
-
-const login: NextPage = () => {
-  return <></>
-}
-
-export default login;

--- a/booklog/pages/makebookclub.tsx
+++ b/booklog/pages/makebookclub.tsx
@@ -1,7 +1,15 @@
 import Seo from "../components/Seo";
 import MakeClubLayout from "../components/BookClub/MakeClub/MakeClubLayout";
+import { useRecoilState } from "recoil";
+import { CurrentLayout, ClubLayoutState } from "../states/recoilLayoutState";
+import { useEffect } from "react";
 
 export default function makebookclub() {
+  const [layoutState, setLayoutState] = useRecoilState(ClubLayoutState);
+
+  useEffect(() => {
+    setLayoutState(CurrentLayout.Header);
+  }, []);
   return (
     <>
       <Seo title="Make Book Club" />

--- a/booklog/pages/portfolio.tsx
+++ b/booklog/pages/portfolio.tsx
@@ -2,8 +2,17 @@ import { NextPage } from "next";
 import BookReviewForm from "../components/portfolio/BookReviewForm";
 import PageTitle from "../components/portfolio/PageTitle";
 import PortfolioNav from "../components/portfolio/PortfolioNav";
+import { useRecoilState } from "recoil";
+import { CurrentLayout, ClubLayoutState } from "../states/recoilLayoutState";
+import { useEffect } from "react";
 
 const portfolio: NextPage = () => {
+  const [layoutState, setLayoutState] = useRecoilState(ClubLayoutState);
+
+  useEffect(() => {
+    setLayoutState(CurrentLayout.Header);
+  }, []);
+
   //portfolio 페이지
   const title = "포트폴리오 확인하기";
   const sub =

--- a/booklog/pages/signup.tsx
+++ b/booklog/pages/signup.tsx
@@ -1,6 +1,14 @@
 import { NextPage } from "next";
+import { useRecoilState } from "recoil";
+import { CurrentLayout, ClubLayoutState } from "../states/recoilLayoutState";
+import { useEffect } from "react";
 
 const signup: NextPage = () => {
+  const [layoutState, setLayoutState] = useRecoilState(ClubLayoutState);
+
+  useEffect(() => {
+    setLayoutState(CurrentLayout.Header);
+  }, []);
   return <></>;
 };
 

--- a/booklog/res/interface/BookClubInterface.ts
+++ b/booklog/res/interface/BookClubInterface.ts
@@ -24,3 +24,9 @@ export enum Stage {
   Join, //가입신청
   Complete, //가입신청 완료
 }
+
+export enum MyStateInClub {
+  NoMember,
+  Waiting,
+  Member
+}

--- a/booklog/res/interface/DynamicBookClubInterface.ts
+++ b/booklog/res/interface/DynamicBookClubInterface.ts
@@ -1,0 +1,13 @@
+export interface clubInfo {
+  name: string;
+  id: number;
+  dates: Array<string>;
+  image: string;
+  info: string;
+  max_num: number;
+  cur_num: number;
+  ment: string;
+  notice: string;
+  onoff: boolean;
+  tags: Array<string>;
+}

--- a/booklog/states/recoilLayoutState.ts
+++ b/booklog/states/recoilLayoutState.ts
@@ -1,0 +1,12 @@
+import { atom } from "recoil";
+
+export enum CurrentLayout {
+  NoHeader,
+  Header,
+  WhiteHeader,
+}
+
+export const ClubLayoutState = atom<CurrentLayout>({
+  key: "layout",
+  default: CurrentLayout.Header,
+});


### PR DESCRIPTION
## 헤더 관리하는 상태
`/states/recoilLayoutState.ts`
```javascript
import { atom } from "recoil";

export enum CurrentLayout {
  NoHeader,
  Header,
  WhiteHeader,
}

export const ClubLayoutState = atom<CurrentLayout>({
  key: "layout",
  default: CurrentLayout.Header,
});
```
- `CurrentLayout` enum 안에 `NoHeader` `Header` `WhiteHeader`로 나누어서 관리
- 기본적으로 동적 페이지 (개별 포트폴리오 / 개별 독서모임)가 아니면 해당 상태를 `Header`로 고정하기 위해서, 각 페이지마다 `useEffect`로 해당 state를 Header로 바꾸어주도록 했어요.
  - 그래서 동적페이지 -> 일반페이지 로오면 무조건 헤더와 네비바가 생깁니다.
  - 우선 제가 사용할 `NoHeader`는 헤더와 네비바 모두 없기 때문에 **Layout.tsx를 변경하였습니다.**
  ```javascript
  ...
       {layoutState === CurrentLayout.Header ? (
          <>
            <header>
              <Header />
              <User />
            </header>
            <div className="content">{props.children}</div>
            <Footer />
          </>
        ) : (
          <div className="content">{props.children}</div>
        )}
  ...
  ``` 
- 때문에 은아님도 Layout.tsx와 포트폴리오 동적 페이지에서 해당 state(`WhiteHeader`)를 통해 컴포넌트를 재구성하시면 돼요!